### PR TITLE
fix: repair CI/CD pipelines and replace deprecated deployment

### DIFF
--- a/.github/workflows/activity-tracker.yml
+++ b/.github/workflows/activity-tracker.yml
@@ -82,20 +82,20 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔧 Install Activity Analysis Dependencies (Pre-cache)
-        run: |
-          echo "📦 **INSTALLING ACTIVITY ANALYSIS DEPENDENCIES (PRE-CACHE)**"
-          cd .github/scripts
-          npm cache clean --force
-          npm install
-          cd ../..
-          echo "✅ Analysis dependencies installed"
-
       - name: 📦 Setup Node.js Environment
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
+
+      - name: 🔧 Install Activity Analysis Dependencies
+        run: |
+          echo "📦 **INSTALLING ACTIVITY ANALYSIS DEPENDENCIES**"
+          cd .github/scripts
+          npm cache clean --force
+          npm install
+          cd ../..
+          echo "✅ Analysis dependencies installed"
 
       - name: 🧹 Clean old data snapshots
         run: |
@@ -134,8 +134,8 @@ jobs:
             sed 's/.*\.//' | sort | uniq -c | sort -nr > temp_languages.txt
 
           # Code change metrics (with safety bounds)
-          LINES_ADDED=$(git log --since="${LOOKBACK_DAYS} days ago" --numstat | awk '{if($1 != "-") add += $1} END {print add+0}')
-          LINES_REMOVED=$(git log --since="${LOOKBACK_DAYS} days ago" --numstat | awk '{if($2 != "-") del += $2} END {print del+0}')
+          LINES_ADDED=$(git log --since="${LOOKBACK_DAYS} days ago" --numstat | awk '{if($1 != "-") add += $1} END {printf "%.0f", add+0}')
+          LINES_REMOVED=$(git log --since="${LOOKBACK_DAYS} days ago" --numstat | awk '{if($2 != "-") del += $2} END {printf "%.0f", del+0}')
           NET_LINES=$((LINES_ADDED - LINES_REMOVED))
 
           # Cap extreme values (likely binary files or data corruption)

--- a/.github/workflows/cv-enhancement.yml
+++ b/.github/workflows/cv-enhancement.yml
@@ -272,9 +272,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔧 Install Dependencies (Pre-cache)
+      - name: 📦 Setup Node.js Environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 🔧 Install Dependencies
         run: |
-          echo "📦 **INSTALLING CV ENHANCEMENT DEPENDENCIES (PRE-CACHE)**"
+          echo "📦 **INSTALLING CV ENHANCEMENT DEPENDENCIES**"
           cd .github/scripts
           npm cache clean --force
           npm install
@@ -288,12 +294,6 @@ jobs:
           npm test
           cd ../..
           echo "✅ Unit tests passed"
-
-      - name: 📦 Setup Node.js Environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
 
       - name: 🌐 Install Browser Dependencies
         run: |
@@ -396,7 +396,7 @@ jobs:
             echo "⚠️ Claude AI enhancement failed (exit code: $ENHANCEMENT_EXIT_CODE), continuing with existing content"
           fi
 
-          cd ../...
+          cd ../..
 
       - name: Content Validation Gate
         if: needs.cv-intelligence-analysis.outputs.ai-budget != 'insufficient'
@@ -578,12 +578,21 @@ jobs:
             echo "⚠️ PDF not found in dist/assets/, PDF download will not be available"
           fi
 
-      - name: 🚀 Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          cname: ${{ secrets.CUSTOM_DOMAIN }}
+      - name: 🚀 Deploy Generated Assets to Main Branch
+        run: |
+          echo "🚀 **DEPLOYING GENERATED ASSETS**"
+
+          # Copy generated files from dist/ back into the working tree
+          if [ -d "dist" ]; then
+            # Copy generated assets over source files
+            cp -r dist/assets/* assets/ 2>/dev/null || true
+            cp -r dist/data/* data/ 2>/dev/null || true
+            [ -f dist/index.html ] && cp dist/index.html index.html
+
+            echo "✅ Generated assets staged for commit"
+          else
+            echo "⚠️ No dist directory found, skipping asset deploy"
+          fi
 
       - name: 📈 Usage Analytics Recording
         if: always()


### PR DESCRIPTION
## Summary
- Fix `cd ../...` typo in cv-enhancement.yml (hard blocker — caused shell error every run)
- Reorder `npm install` to run after `actions/setup-node@v4` in both workflows (was using system Node instead of v20)
- Replace deprecated `peaceiris/actions-gh-pages@v3` (Node 16) with direct file copy + existing git commit step — Pages serves from `main:/`, not `gh-pages`
- Fix awk scientific notation bug in activity-tracker.yml (`print` → `printf "%.0f"`) to prevent bash `$(( ))` arithmetic failures on large line counts

## Test plan
- [ ] Verify YAML syntax is valid (pre-commit `check yaml` hook passed)
- [ ] Confirm `cd ../..` resolves correctly by tracing working directory through job steps
- [ ] Confirm npm install runs after setup-node in step order for both workflows
- [ ] After merge: `gh workflow enable cv-enhancement.yml` and trigger manual run
- [ ] Verify CNAME file is unaffected (no peaceiris to overwrite it)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)