### PR TITLE
fix: prevent test runner deserialization race in Node 20

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -7,7 +7,7 @@
     "analyze": "node activity-analyzer.js",
     "enhance": "node claude-enhancer.js",
     "generate": "node cv-generator.js",
-    "test": "node --test activity-analyzer.test.js claude-enhancer.test.js cv-generator.test.js",
+    "test": "node --test --test-concurrency=1 activity-analyzer.test.js claude-enhancer.test.js cv-generator.test.js",
     "lint": "eslint --max-warnings=0 *.js",
     "format": "prettier --write *.js"
   },


### PR DESCRIPTION
## Summary
- Add `--test-concurrency=1` to the npm test script to run test files sequentially
- Fixes `Unable to deserialize cloned data due to invalid or unsupported version` error in CI (Node v20.20.0)
- This is a known Node 20 test runner IPC race condition when running multiple test files concurrently

## Test plan
- [x] All 8 tests pass locally with the fix
- [ ] CI should pass on this PR
- [ ] After merge: re-trigger cv-enhancement workflow to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.ai/claude-code)