### PR TITLE
fix: pass ANTHROPIC_API_KEY to enhancement step

### DIFF
--- a/.github/workflows/cv-enhancement.yml
+++ b/.github/workflows/cv-enhancement.yml
@@ -370,11 +370,6 @@ jobs:
           echo "🎨 Creativity level: ${{ github.event.inputs.ai_creativity || 'balanced' }}"
           echo ""
 
-          # Execute AI enhancement with comprehensive error handling
-          AI_BUDGET="${{ needs.cv-intelligence-analysis.outputs.ai-budget }}"
-          CREATIVITY="${{ github.event.inputs.ai_creativity || 'balanced' }}"
-          ACTIVITY_SCORE="${{ needs.cv-intelligence-analysis.outputs.activity-score }}"
-
           cd .github/scripts
 
           # Verify claude-enhancer.js exists before running
@@ -385,8 +380,11 @@ jobs:
           fi
 
           # Run with timeout and error handling
+          # Use set +e so process.exit(1) from the script doesn't abort the step
+          set +e
           timeout 600 node claude-enhancer.js
           ENHANCEMENT_EXIT_CODE=$?
+          set -e
 
           if [ $ENHANCEMENT_EXIT_CODE -eq 0 ]; then
             echo "✅ Claude AI enhancement completed successfully"
@@ -397,6 +395,8 @@ jobs:
           fi
 
           cd ../..
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Content Validation Gate
         if: needs.cv-intelligence-analysis.outputs.ai-budget != 'insufficient'


### PR DESCRIPTION
## Summary
- Add `env: ANTHROPIC_API_KEY` to the Claude AI Content Enhancement step — the secret exists in the repo but wasn't exposed to the step
- Wrap script call with `set +e` / `set -e` so `process.exit(1)` from `claude-enhancer.js` doesn't bypass the step's "continuing with existing content" error handling

## Context
The previous run (21888852640) failed with `❌ ANTHROPIC_API_KEY environment variable is required` because the step had no `env:` block. The step's error handling code was also unreachable because GitHub Actions uses `set -e` by default, so `process.exit(1)` aborted the step before `ENHANCEMENT_EXIT_CODE=$?` could capture it.

## Test plan
- [ ] CI checks pass on this PR
- [ ] After merge: trigger manual cv-enhancement run to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.ai/claude-code)